### PR TITLE
Create ProtoBuffSerializedStrand.proto

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,7 +7,7 @@ def protocVersion = protobufVersion
 
 dependencies {
     compileOnly "javax.annotation:javax.annotation-api:1.2"
-    api 'sustain.synopsis:sketch:1.0.1'
+    api 'sustain.synopsis:sketch:1.0.2'
     api "io.grpc:grpc-protobuf:${grpcVersion}"
     api "io.grpc:grpc-stub:${grpcVersion}"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"

--- a/common/src/main/java/sustain/synopsis/common/Strand.java
+++ b/common/src/main/java/sustain/synopsis/common/Strand.java
@@ -1,5 +1,6 @@
 package sustain.synopsis.common;
 
+import com.google.protobuf.ByteString;
 import sustain.synopsis.sketch.dataset.feature.Feature;
 import sustain.synopsis.sketch.graph.Path;
 import sustain.synopsis.sketch.graph.Vertex;
@@ -151,8 +152,8 @@ public class Strand {
         return "Strand{" + "key='" + key + '\'' + '}';
     }
 
-    public byte[] serializeAsProtoBuff() {
-        return toProtoBuff().toByteArray();
+    public ByteString serializeAsProtoBuff() {
+        return toProtoBuff().toByteString();
     }
 
     ProtoBuffSerializedStrand toProtoBuff() {

--- a/common/src/main/java/sustain/synopsis/common/Strand.java
+++ b/common/src/main/java/sustain/synopsis/common/Strand.java
@@ -151,23 +151,23 @@ public class Strand {
         return "Strand{" + "key='" + key + '\'' + '}';
     }
 
-    public ProtoBuffSerializedStrand toProtoBuff() {
+    public byte[] serializeAsProtoBuff() {
+        return toProtoBuff().toByteArray();
+    }
+
+    ProtoBuffSerializedStrand toProtoBuff() {
         ProtoBuffSerializedStrand protoBuffStrand =
                 ProtoBuffSerializedStrand.newBuilder().setGeohash(geohash).setStartTS(fromTimeStamp).buildPartial();
         ProtoBuffSerializedStrand.Builder builder = protoBuffStrand.toBuilder();
-        for (Vertex v : path) {
-            builder.addFeatures(v.getLabel().getDouble());
-            if (v.hasData()) {
-                RunningStatisticsND statistics = v.getData().statistics;
-                builder.setObservationCount(statistics.count());
-                if (statistics.count() > 1) {
-                    builder.addAllMean(Arrays.stream(statistics.means()).boxed().collect(Collectors.toList()));
-                    builder.addAllM2(Arrays.stream(statistics.m2()).boxed().collect(Collectors.toList()));
-                    builder.addAllMax(Arrays.stream(statistics.maxes()).boxed().collect(Collectors.toList()));
-                    builder.addAllMin(Arrays.stream(statistics.mins()).boxed().collect(Collectors.toList()));
-                    builder.addAllS2(Arrays.stream(statistics.ss()).boxed().collect(Collectors.toList()));
-                }
-            }
+        builder.addAllFeatures(path.stream().map(v -> v.getLabel().getDouble()).collect(Collectors.toList()));
+        RunningStatisticsND statistics = path.get(path.size() - 1).getData().statistics;
+        builder.setObservationCount(statistics.count());
+        if (statistics.count() > 1) {
+            builder.addAllMean(Arrays.stream(statistics.means()).boxed().collect(Collectors.toList()));
+            builder.addAllM2(Arrays.stream(statistics.m2()).boxed().collect(Collectors.toList()));
+            builder.addAllMax(Arrays.stream(statistics.maxes()).boxed().collect(Collectors.toList()));
+            builder.addAllMin(Arrays.stream(statistics.mins()).boxed().collect(Collectors.toList()));
+            builder.addAllS2(Arrays.stream(statistics.ss()).boxed().collect(Collectors.toList()));
         }
         return builder.build();
     }

--- a/common/src/main/java/sustain/synopsis/common/StrandSerializationUtil.java
+++ b/common/src/main/java/sustain/synopsis/common/StrandSerializationUtil.java
@@ -1,0 +1,65 @@
+package sustain.synopsis.common;
+
+import sustain.synopsis.sketch.dataset.feature.Feature;
+import sustain.synopsis.sketch.graph.DataContainer;
+import sustain.synopsis.sketch.graph.Path;
+import sustain.synopsis.sketch.stat.RunningStatisticsND;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class StrandSerializationUtil {
+    public static ProtoBuffSerializedStrand toProtoBuff(Strand strand) {
+        ProtoBuffSerializedStrand protoBuffStrand =
+                ProtoBuffSerializedStrand.newBuilder().setGeohash(strand.getGeohash())
+                                         .setStartTS(strand.getFromTimeStamp()).buildPartial();
+        ProtoBuffSerializedStrand.Builder builder = protoBuffStrand.toBuilder();
+        Path path = strand.getPath();
+        builder.addAllFeatures(path.stream().map(v -> v.getLabel().getDouble()).collect(Collectors.toList()));
+        RunningStatisticsND statistics = path.get(path.size() - 1).getData().statistics;
+        builder.setObservationCount(statistics.count());
+        /* Copy the mean values even in the case of n = 1 because they are non discretized values.
+        With this approach, we can correctly merge strands with single observations.
+        */
+        builder.addAllMean(Arrays.stream(statistics.means()).boxed().collect(Collectors.toList()));
+        if (statistics.count() > 1) {
+            builder.addAllM2(Arrays.stream(statistics.m2()).boxed().collect(Collectors.toList()));
+            builder.addAllMax(Arrays.stream(statistics.maxes()).boxed().collect(Collectors.toList()));
+            builder.addAllMin(Arrays.stream(statistics.mins()).boxed().collect(Collectors.toList()));
+            builder.addAllS2(Arrays.stream(statistics.ss()).boxed().collect(Collectors.toList()));
+        }
+        return builder.build();
+    }
+
+    public static Strand fromProtoBuff(ProtoBuffSerializedStrand strand) {
+        List<Double> featuresList = strand.getFeaturesList();
+        Path path = new Path(featuresList.size());
+        featuresList.stream().map(Feature::new).forEach(path::add);
+        // set the data container
+        RunningStatisticsND statisticsND;
+        if (strand.getObservationCount() > 1) {
+            statisticsND = new RunningStatisticsND(featuresList.size());
+            statisticsND.setMean(listToArray(strand.getMeanList()));
+            statisticsND.setM2(listToArray(strand.getM2List()));
+            statisticsND.setMax(listToArray(strand.getMaxList()));
+            statisticsND.setMin(listToArray(strand.getMinList()));
+            statisticsND.setSs(listToArray(strand.getS2List()));
+        } else {
+            // in case of single observation Strands mean values are always non discretized data
+            statisticsND = new RunningStatisticsND(listToArray(strand.getMeanList()));
+        }
+        statisticsND.setN(strand.getObservationCount());
+        path.get(path.size() - 1).setData(new DataContainer(statisticsND));
+        // We do not keep the endTS in the protobuff serialized strand because it can get resolved using
+        // the schema
+        return new Strand(strand.getGeohash(), strand.getStartTS(), strand.getStartTS(), path);
+    }
+
+    private static double[] listToArray(List<Double> list) {
+        double[] array = new double[list.size()];
+        IntStream.range(0, list.size()).forEach(i -> array[i] = list.get(i));
+        return array;
+    }
+}

--- a/common/src/main/proto/ProtoBuffSerializedStrand.proto
+++ b/common/src/main/proto/ProtoBuffSerializedStrand.proto
@@ -5,8 +5,8 @@ option java_package = "sustain.synopsis.common";
 
 message ProtoBuffSerializedStrand {
     string geohash = 1;
-    int64 from = 2;
-    int64 to = 3;
+    // start timestamp as an epoch - endTS can be derived by referring to the schema
+    int64 startTS = 2;
     // feature values - can be discretized values or the original values as explained below
     repeated double features = 4;
     // Number of observations

--- a/common/src/main/proto/ProtoBuffSerializedStrand.proto
+++ b/common/src/main/proto/ProtoBuffSerializedStrand.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sustain.synopsis.common";
+
+message ProtoBuffSerializedStrand {
+    string geohash = 1;
+    int64 from = 2;
+    int64 to = 3;
+    // feature values - can be discretized values or the original values as explained below
+    repeated double features = 4;
+    // Number of observations
+    int32 observationCount = 5;
+    // Serialized data container
+    // As an optimization, data container fields are set only if the observationCount > 1.
+    // The consumer should always check the observationCount before accessing the data container fields.
+    // If observationCount == 1, then features will not be discretized and data container fields can be derived from
+    // the features. In this case, the strand represents a single observation.
+    // If observationCount > 1, then features will be discretized and data container fields will be set. In this case
+    // the strand represents an aggregation of multiple observations.
+    repeated double mean = 6;
+    repeated double m2 = 7;
+    repeated double min = 8;
+    repeated double max = 9;
+    repeated double s2 = 10;
+}

--- a/common/src/main/proto/ProtoBuffSerializedStrand.proto
+++ b/common/src/main/proto/ProtoBuffSerializedStrand.proto
@@ -7,18 +7,19 @@ message ProtoBuffSerializedStrand {
     string geohash = 1;
     // start timestamp as an epoch - endTS can be derived by referring to the schema
     int64 startTS = 2;
-    // feature values - can be discretized values or the original values as explained below
+    // discretized feature values
     repeated double features = 3;
     // Number of observations
     int64 observationCount = 4;
     // Serialized data container
-    // As an optimization, data container fields are set only if the observationCount > 1.
-    // The consumer should always check the observationCount before accessing the data container fields.
-    // If observationCount == 1, then features will not be discretized and data container fields can be derived from
-    // the features. In this case, the strand represents a single observation.
-    // If observationCount > 1, then features will be discretized and data container fields will be set. In this case
-    // the strand represents an aggregation of multiple observations.
+    // If the observation count == 1, this field contains the non-discretized feature values which will be used
+    // for deriving the rest of the data container.
+    // If the observation count > 1, then it will contain the mean values for individual features
     repeated double mean = 5;
+    // As an optimization, rest of the data container fields are set only if the observationCount > 1.
+    // The consumer should always check the observationCount before accessing the data container fields.
+    // If observationCount == 1, data container fields will not be set and they can be derived from the mean values.
+    // If observationCount > 1, then the data container variables will be set.
     repeated double m2 = 6;
     repeated double min = 7;
     repeated double max = 8;

--- a/common/src/main/proto/ProtoBuffSerializedStrand.proto
+++ b/common/src/main/proto/ProtoBuffSerializedStrand.proto
@@ -8,9 +8,9 @@ message ProtoBuffSerializedStrand {
     // start timestamp as an epoch - endTS can be derived by referring to the schema
     int64 startTS = 2;
     // feature values - can be discretized values or the original values as explained below
-    repeated double features = 4;
+    repeated double features = 3;
     // Number of observations
-    int32 observationCount = 5;
+    int64 observationCount = 4;
     // Serialized data container
     // As an optimization, data container fields are set only if the observationCount > 1.
     // The consumer should always check the observationCount before accessing the data container fields.
@@ -18,9 +18,9 @@ message ProtoBuffSerializedStrand {
     // the features. In this case, the strand represents a single observation.
     // If observationCount > 1, then features will be discretized and data container fields will be set. In this case
     // the strand represents an aggregation of multiple observations.
-    repeated double mean = 6;
-    repeated double m2 = 7;
-    repeated double min = 8;
-    repeated double max = 9;
-    repeated double s2 = 10;
+    repeated double mean = 5;
+    repeated double m2 = 6;
+    repeated double min = 7;
+    repeated double max = 8;
+    repeated double s2 = 9;
 }

--- a/common/src/main/proto/ingestion_service.proto
+++ b/common/src/main/proto/ingestion_service.proto
@@ -12,6 +12,8 @@ message Strand {
     string entityId = 1;
     int64 fromTs = 2;
     int64 toTs = 3;
+    // Instead of using ProtoBuffSerializedStrand, we use serialized bytes here to avoid a deserialization/serialization
+    // cycle at the storage end. This byte[] gets directly stored on the disk.
     bytes bytes = 4;
 }
 

--- a/common/src/main/proto/targeted_query_service.proto
+++ b/common/src/main/proto/targeted_query_service.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "ProtoBuffSerializedStrand.proto";
+
 option java_multiple_files = true;
 option java_package = "sustain.synopsis.dht.store.services";
 
@@ -18,15 +20,7 @@ message TargetQueryRequest {
 
 // a single response message may pack zero or more strands
 message TargetQueryResponse {
-    repeated MatchingStrand strands = 1;
-}
-
-// a matching strand for a given query
-message MatchingStrand {
-    string spatialScope = 1;
-    int64 fromTS = 2;
-    int64 toTS = 3;
-    bytes strand = 4;
+    repeated ProtoBuffSerializedStrand strands = 1;
 }
 
 // predicates are combined using combine operators to form expressions

--- a/common/src/test/java/sustain/synopsis/common/StrandTest.java
+++ b/common/src/test/java/sustain/synopsis/common/StrandTest.java
@@ -74,13 +74,9 @@ public class StrandTest {
         Strand strand4 = new Strand("9xj", (1391216300000L - 3600 * 1000), 1391216400000L, path);
         Assertions.assertNotEquals(strand, strand4);
 
-        // different to timestamp
-        Strand strand5 = new Strand("9xj", (1391216400000L - 3600 * 1000), 1391216500000L, path);
-        Assertions.assertNotEquals(strand, strand5);
-
         // different path
         Path path2 = new Path(3);
-        Strand strand6 = createStrand(path, "9xj", (1391216400000L - 3600 * 1000), 1391216400000L, 1.34, 1.5, 4.6);
+        Strand strand6 = createStrand(path2, "9xj", (1391216400000L - 3600 * 1000), 1391216400000L, 1.34, 1.5, 4.6);
         Assertions.assertNotEquals(strand, strand6);
 
         // different metadata
@@ -111,25 +107,21 @@ public class StrandTest {
         // different path lengths
         Path path2 = new Path(1);
         final Strand strand2 = createStrand(path2, "9xj", (1391216400000L - 3600 * 1000), 1391216400000L, 1.34);
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            strand1.merge(strand2);
-        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> strand1.merge(strand2));
 
         // different paths
         path2 = new Path(2);
         final Strand strand3 = createStrand(path2, "9xj", (1391216400000L - 3600 * 1000), 1391216400000L, 1.34, 1.6);
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            strand1.merge(strand3);
-        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> strand1.merge(strand3));
     }
 
     @Test
-    void testToProtoBuffWithDataContainer() {
+    void testToProtoBuffWithMultipleObservation() {
         Strand strand1 = createStrand(new Path(3), "9xj", 1000, 2000, 1.34, 1.5, 100.5);
         Strand strand2 = createStrand(new Path(3), "9xj", 1000, 2000, 1.34, 1.5, 100.5);
         strand1.merge(strand2);
 
-        ProtoBuffSerializedStrand protoBuffSerializedStrand = strand1.toProtoBuff();
+        ProtoBuffSerializedStrand protoBuffSerializedStrand = StrandSerializationUtil.toProtoBuff(strand1);
         Assertions.assertEquals("9xj", protoBuffSerializedStrand.getGeohash());
         Assertions.assertEquals(1000, protoBuffSerializedStrand.getStartTS());
         Assertions.assertEquals(
@@ -152,9 +144,9 @@ public class StrandTest {
     }
 
     @Test
-    void testToProtoBuffWithoutDataContainer() {
+    void testToProtoBuffWithOneObservation() {
         Strand strand = createStrand(new Path(2), "9xj", 1000, 2000, 1.34, 1.5, 100.5);
-        ProtoBuffSerializedStrand protoBuffSerializedStrand = strand.toProtoBuff();
+        ProtoBuffSerializedStrand protoBuffSerializedStrand = StrandSerializationUtil.toProtoBuff(strand);
         Assertions.assertEquals("9xj", protoBuffSerializedStrand.getGeohash());
         Assertions.assertEquals(1000, protoBuffSerializedStrand.getStartTS());
         Assertions
@@ -162,19 +154,39 @@ public class StrandTest {
                               protoBuffSerializedStrand.getFeaturesList());
         RunningStatisticsND stats = strand.getPath().get(strand.getPath().size() - 1).getData().statistics;
         Assertions.assertEquals(stats.count(), protoBuffSerializedStrand.getObservationCount());
+        Assertions.assertEquals(Arrays.stream(stats.means()).boxed().collect(Collectors.toList()),
+                                protoBuffSerializedStrand.getMeanList());
         // rest of the data container should be empty
         Assertions.assertEquals(0, protoBuffSerializedStrand.getMaxList().size());
         Assertions.assertEquals(0, protoBuffSerializedStrand.getMinList().size());
         Assertions.assertEquals(0, protoBuffSerializedStrand.getM2List().size());
-        Assertions.assertEquals(0, protoBuffSerializedStrand.getMeanList().size());
         Assertions.assertEquals(0, protoBuffSerializedStrand.getS2List().size());
     }
 
     @Test
     void testSerializeAsProtoBuff() {
         Strand strand = createStrand(new Path(3), "9xj", 1000, 2000, 1.34, 1.5, 100.5);
-        ProtoBuffSerializedStrand protoBuffSerializedStrand = strand.toProtoBuff();
+        ProtoBuffSerializedStrand protoBuffSerializedStrand = StrandSerializationUtil.toProtoBuff(strand);
         Assertions.assertEquals(protoBuffSerializedStrand.toByteString(), strand.serializeAsProtoBuff());
+    }
+
+    @Test
+    void testFromProtoBuffToStrandWithOneObservation() {
+        // strands with a single observation
+        Strand originalStrand = createStrand(new Path(3), "9xj", 1000, 2000, 1.34, 1.5, 100.5);
+        ProtoBuffSerializedStrand protoBuffSerializedStrand = StrandSerializationUtil.toProtoBuff(originalStrand);
+        Strand convertedStrand = StrandSerializationUtil.fromProtoBuff(protoBuffSerializedStrand);
+        compareStrands(originalStrand, convertedStrand);
+    }
+
+    @Test
+    void testFromProtoBuffToStrandWithMultipleObservation() {
+        Strand strand1 = createStrand(new Path(3), "9xj", 1000, 2000, 1.34, 1.5, 100.5);
+        Strand strand2 = createStrand(new Path(3), "9xj", 1000, 2000, 1.34, 1.5, 100.5);
+        strand1.merge(strand2);
+        ProtoBuffSerializedStrand protoBuffSerializedStrand = StrandSerializationUtil.toProtoBuff(strand1);
+        Strand convertedStrand = StrandSerializationUtil.fromProtoBuff(protoBuffSerializedStrand);
+        compareStrands(strand1, convertedStrand);
     }
 
     private Strand createStrand(Path path, String geohash, long ts, long to, double... features) {
@@ -185,5 +197,23 @@ public class StrandTest {
         DataContainer container = new DataContainer(runningStats);
         path.get(path.size() - 1).setData(container);
         return new Strand(geohash, ts, to, path);
+    }
+
+    private void compareStrands(Strand originalStrand, Strand convertedStrand) {
+        Assertions.assertEquals(originalStrand.getGeohash(), convertedStrand.getGeohash());
+        Assertions.assertEquals(originalStrand.getFromTimeStamp(), convertedStrand.getFromTimeStamp());
+        Assertions.assertEquals(
+                originalStrand.getPath().stream().map(f -> f.getLabel().getDouble()).collect(Collectors.toList()),
+                convertedStrand.getPath().stream().map(f -> f.getLabel().getDouble()).collect(Collectors.toList()));
+        RunningStatisticsND originalStats =
+                originalStrand.getPath().get(originalStrand.getPath().size()-1).getData().statistics;
+        RunningStatisticsND convertedStats =
+                convertedStrand.getPath().get(originalStrand.getPath().size()-1).getData().statistics;
+        Assertions.assertEquals(originalStats.count(), convertedStats.count());
+        Assertions.assertArrayEquals(originalStats.means(), convertedStats.means());
+        Assertions.assertArrayEquals(originalStats.maxes(), convertedStats.maxes());
+        Assertions.assertArrayEquals(originalStats.mins(), convertedStats.mins());
+        Assertions.assertArrayEquals(originalStats.m2(), convertedStats.m2());
+        Assertions.assertArrayEquals(originalStats.ss(), convertedStats.ss());
     }
 }

--- a/common/src/test/java/sustain/synopsis/common/StrandTest.java
+++ b/common/src/test/java/sustain/synopsis/common/StrandTest.java
@@ -171,10 +171,10 @@ public class StrandTest {
     }
 
     @Test
-    void testSerializeAsProtoBuff(){
-        Strand strand = createStrand(new Path(2), "9xj", 1000, 2000, 1.34, 1.5, 100.5);
+    void testSerializeAsProtoBuff() {
+        Strand strand = createStrand(new Path(3), "9xj", 1000, 2000, 1.34, 1.5, 100.5);
         ProtoBuffSerializedStrand protoBuffSerializedStrand = strand.toProtoBuff();
-        Assertions.assertArrayEquals(protoBuffSerializedStrand.toByteArray(), strand.serializeAsProtoBuff());
+        Assertions.assertEquals(protoBuffSerializedStrand.toByteString(), strand.serializeAsProtoBuff());
     }
 
     private Strand createStrand(Path path, String geohash, long ts, long to, double... features) {

--- a/common/src/test/java/sustain/synopsis/common/StrandTest.java
+++ b/common/src/test/java/sustain/synopsis/common/StrandTest.java
@@ -170,6 +170,13 @@ public class StrandTest {
         Assertions.assertEquals(0, protoBuffSerializedStrand.getS2List().size());
     }
 
+    @Test
+    void testSerializeAsProtoBuff(){
+        Strand strand = createStrand(new Path(2), "9xj", 1000, 2000, 1.34, 1.5, 100.5);
+        ProtoBuffSerializedStrand protoBuffSerializedStrand = strand.toProtoBuff();
+        Assertions.assertArrayEquals(protoBuffSerializedStrand.toByteArray(), strand.serializeAsProtoBuff());
+    }
+
     private Strand createStrand(Path path, String geohash, long ts, long to, double... features) {
         for (int i = 0; i < features.length; i++) {
             path.add(new Feature("feature_" + (i + 1), features[i]));

--- a/dht/src/main/java/sustain/synopsis/dht/store/entity/EntityStore.java
+++ b/dht/src/main/java/sustain/synopsis/dht/store/entity/EntityStore.java
@@ -7,10 +7,7 @@ import sustain.synopsis.dht.store.query.MatchedSSTable;
 import sustain.synopsis.dht.store.query.QueryException;
 import sustain.synopsis.dht.store.query.QueryUtil;
 import sustain.synopsis.dht.store.services.Expression;
-import sustain.synopsis.storage.lsmtree.ChecksumGenerator;
-import sustain.synopsis.storage.lsmtree.MemTable;
-import sustain.synopsis.storage.lsmtree.Metadata;
-import sustain.synopsis.storage.lsmtree.SSTableWriter;
+import sustain.synopsis.storage.lsmtree.*;
 import sustain.synopsis.storage.lsmtree.compress.BlockCompressor;
 import sustain.synopsis.storage.lsmtree.compress.LZ4BlockCompressor;
 
@@ -125,7 +122,7 @@ public class EntityStore {
             if (isMemTableFull) {
                 purgeMemTable(session, memTable);
             }
-        } catch (IOException | StorageException e) {
+        } catch (IOException | StorageException | MergeError e) {
             logger.error("Error storing the strand.", e);
             return false;
         }

--- a/dht/src/test/java/sustain/synopsis/dht/store/StrandStorageKeyValueTest.java
+++ b/dht/src/test/java/sustain/synopsis/dht/store/StrandStorageKeyValueTest.java
@@ -3,11 +3,13 @@ package sustain.synopsis.dht.store;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import sustain.synopsis.common.Strand;
+import sustain.synopsis.common.StrandSerializationUtil;
 import sustain.synopsis.sketch.dataset.feature.Feature;
 import sustain.synopsis.sketch.graph.DataContainer;
 import sustain.synopsis.sketch.graph.Path;
 import sustain.synopsis.sketch.serialization.SerializationOutputStream;
 import sustain.synopsis.sketch.stat.RunningStatisticsND;
+import sustain.synopsis.storage.lsmtree.MergeError;
 
 import java.io.*;
 
@@ -50,7 +52,7 @@ public class StrandStorageKeyValueTest {
     }
 
     @Test
-    void testStrandStorageSerialization() throws IOException {
+    void testStrandStorageKeySerialization() throws IOException {
         StrandStorageKey key = new StrandStorageKey(from, to);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(baos);
@@ -78,20 +80,20 @@ public class StrandStorageKeyValueTest {
     }
 
     @Test
-    void testStrandStorageValueMerge() throws IOException {
+    void testStrandStorageValueMerge() throws IOException, MergeError {
         Strand strand1 = createStrand("9xa", from, to, 1.0, 2.0, 3.0);
         Strand strand2 = createStrand("9xa", from, to, 1.0, 2.0, 3.0);
-        StrandStorageValue value1 = new StrandStorageValue(serializeStrand(strand1));
-        StrandStorageValue value2 = new StrandStorageValue(serializeStrand(strand2));
+        StrandStorageValue value1 = new StrandStorageValue(StrandSerializationUtil.toProtoBuff(strand1).toByteArray());
+        StrandStorageValue value2 = new StrandStorageValue(StrandSerializationUtil.toProtoBuff(strand2).toByteArray());
         value1.merge(value2);
         strand1.merge(strand2);
         Assertions.assertEquals(value1.getStrand(), strand1);
     }
 
     @Test
-    void testStrandSerialization() throws IOException {
+    void testStrandStorageValueSerialization() throws IOException {
         Strand strand = createStrand("9xa", from, to, 1.0, 2.0, 3.0);
-        StrandStorageValue val = new StrandStorageValue(serializeStrand(strand));
+        StrandStorageValue val = new StrandStorageValue(StrandSerializationUtil.toProtoBuff(strand).toByteArray());
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(baos);
         byte[] serializedData;

--- a/dht/src/test/java/sustain/synopsis/dht/store/StrandStorageKeyValueTest.java
+++ b/dht/src/test/java/sustain/synopsis/dht/store/StrandStorageKeyValueTest.java
@@ -7,7 +7,6 @@ import sustain.synopsis.common.StrandSerializationUtil;
 import sustain.synopsis.sketch.dataset.feature.Feature;
 import sustain.synopsis.sketch.graph.DataContainer;
 import sustain.synopsis.sketch.graph.Path;
-import sustain.synopsis.sketch.serialization.SerializationOutputStream;
 import sustain.synopsis.sketch.stat.RunningStatisticsND;
 import sustain.synopsis.storage.lsmtree.MergeError;
 
@@ -29,13 +28,7 @@ public class StrandStorageKeyValueTest {
     }
 
     public static byte[] serializeStrand(Strand strand) throws IOException {
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             SerializationOutputStream sos = new SerializationOutputStream(baos)) {
-            strand.serialize(sos);
-            sos.flush();
-            baos.flush();
-            return baos.toByteArray();
-        }
+        return StrandSerializationUtil.toProtoBuff(strand).toByteArray();
     }
 
     @Test
@@ -83,8 +76,8 @@ public class StrandStorageKeyValueTest {
     void testStrandStorageValueMerge() throws IOException, MergeError {
         Strand strand1 = createStrand("9xa", from, to, 1.0, 2.0, 3.0);
         Strand strand2 = createStrand("9xa", from, to, 1.0, 2.0, 3.0);
-        StrandStorageValue value1 = new StrandStorageValue(StrandSerializationUtil.toProtoBuff(strand1).toByteArray());
-        StrandStorageValue value2 = new StrandStorageValue(StrandSerializationUtil.toProtoBuff(strand2).toByteArray());
+        StrandStorageValue value1 = new StrandStorageValue(serializeStrand(strand1));
+        StrandStorageValue value2 = new StrandStorageValue(serializeStrand(strand2));
         value1.merge(value2);
         strand1.merge(strand2);
         Assertions.assertEquals(value1.getStrand(), strand1);
@@ -93,7 +86,7 @@ public class StrandStorageKeyValueTest {
     @Test
     void testStrandStorageValueSerialization() throws IOException {
         Strand strand = createStrand("9xa", from, to, 1.0, 2.0, 3.0);
-        StrandStorageValue val = new StrandStorageValue(StrandSerializationUtil.toProtoBuff(strand).toByteArray());
+        StrandStorageValue val = new StrandStorageValue(serializeStrand(strand));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(baos);
         byte[] serializedData;

--- a/dht/src/test/java/sustain/synopsis/dht/store/entity/EntityStoreTest.java
+++ b/dht/src/test/java/sustain/synopsis/dht/store/entity/EntityStoreTest.java
@@ -84,7 +84,7 @@ public class EntityStoreTest {
         Mockito.when(entityStoreJournalMock.init()).thenReturn(true);
         Mockito.when(entityStoreJournalMock.getSequenceId()).thenReturn(0);
         Mockito.when(entityStoreJournalMock.getMetadata()).thenReturn(new ArrayList<>());
-        EntityStore entityStore = new EntityStore("noaa:9xj", entityStoreJournalMock, 200, 50, diskManagerMock);
+        EntityStore entityStore = new EntityStore("noaa:9xj", entityStoreJournalMock, 80, 20, diskManagerMock);
         entityStore.init();
         Mockito.verify(entityStoreJournalMock, Mockito.times(1)).init();
 
@@ -138,7 +138,7 @@ public class EntityStoreTest {
     void testNodeRestart() throws IOException, StorageException {
         MockitoAnnotations.initMocks(this);
         Mockito.when(diskManagerMock.allocate(Mockito.anyLong())).thenReturn(storageDir.getAbsolutePath());
-        EntityStore entityStore = new EntityStore("noaa:9xj", metadataDir.getAbsolutePath(), 200, 50, diskManagerMock);
+        EntityStore entityStore = new EntityStore("noaa:9xj", metadataDir.getAbsolutePath(), 80, 20, diskManagerMock);
         entityStore.init();
         IngestionSession session = new IngestionSession("bob", System.currentTimeMillis(), 0);
         entityStore.startSession(session);
@@ -159,7 +159,7 @@ public class EntityStoreTest {
 
         // Simulate a node restart
         EntityStore restartedEntityStore =
-                new EntityStore("noaa:9xj", metadataDir.getAbsolutePath(), 200, 50, diskManagerMock);
+                new EntityStore("noaa:9xj", metadataDir.getAbsolutePath(), 80, 20, diskManagerMock);
         restartedEntityStore.init();
         // there were two SSTables written before. So the sequence ID should start from 2.
         assertEquals(2, restartedEntityStore.sequenceId.get());
@@ -191,7 +191,7 @@ public class EntityStoreTest {
         Mockito.when(entityStoreJournalMock.init()).thenReturn(true);
         Mockito.when(entityStoreJournalMock.getSequenceId()).thenReturn(0);
         Mockito.when(entityStoreJournalMock.getMetadata()).thenReturn(new ArrayList<>());
-        EntityStore entityStore = new EntityStore("noaa:9xj", entityStoreJournalMock, 200, 50, diskManagerMock);
+        EntityStore entityStore = new EntityStore("noaa:9xj", entityStoreJournalMock, 80, 20, diskManagerMock);
         entityStore.init();
 
         // start a new session
@@ -207,7 +207,7 @@ public class EntityStoreTest {
         List<MatchedSSTable> results = entityStore.temporalQuery(exp);
         Assertions.assertTrue(results.isEmpty());
 
-        // size of key and value used here - 187 bytes
+        // size of key and value used here - (52 + 16) bytes
         // storing 2 strands should fill out the memTable
         StrandStorageKey key1 = new StrandStorageKey(1000, 1500);
         StrandStorageValue value1 = new StrandStorageValue(serializeStrand(createStrand("9xj", 1000, 1500, 1.0, 2.0)));

--- a/samples/src/main/java/sustain/synopsis/samples/client/noaa/NoaaClient.java
+++ b/samples/src/main/java/sustain/synopsis/samples/client/noaa/NoaaClient.java
@@ -26,7 +26,9 @@ public class NoaaClient {
         String binConfig = args[3];
 
         File baseDir = new File(args[4]);
-        File[] inputFiles = baseDir.listFiles(pathname -> pathname.getName().startsWith("namanl_218_201501") && pathname.getName().endsWith("001.grb" + ".mblob"));
+        File[] inputFiles = baseDir.listFiles(
+                pathname -> pathname.getName().startsWith("namanl_218_201501") && pathname.getName().endsWith(
+                        "001.grb" + ".mblob"));
 
         if (inputFiles == null) {
             System.err.println("No matching files.");
@@ -55,8 +57,9 @@ public class NoaaClient {
             inputFiles[i-4] = new File(args[i]);
         }*/
 
-        for (int i = 0; i < 2; i++) {   // ingest data over two sessions
-            SessionSchema sessionSchema = new SessionSchema(Util.quantizerMapFromFile(binConfig), GEOHASH_LENGTH, TEMPORAL_BRACKET_LENGTH);
+        for (int i = 0; i < Math.min(2, inputFiles.length); i++) {   // ingest data over two sessions
+            SessionSchema sessionSchema =
+                    new SessionSchema(Util.quantizerMapFromFile(binConfig), GEOHASH_LENGTH, TEMPORAL_BRACKET_LENGTH);
 
             StrandPublisher strandPublisher = new SimpleStrandPublisher(dhtNodeAddress, datasetId, sessionId + i);
 //        StrandPublisher strandPublisher = new DHTStrandPublisher(dhtNodeAddress, datasetId, sessionId);
@@ -64,7 +67,9 @@ public class NoaaClient {
 
             StrandRegistry strandRegistry = new StrandRegistry(strandPublisher, 10000, 100);
 
-            NoaaIngester noaaIngester = new NoaaIngester(Arrays.copyOfRange(inputFiles, inputFiles.length / 2 * i, inputFiles.length / 2 * (i + 1)), sessionSchema);
+            NoaaIngester noaaIngester = new NoaaIngester(
+                    Arrays.copyOfRange(inputFiles, (int) Math.ceil(inputFiles.length / 2d) * i,
+                                       (int) Math.ceil(inputFiles.length / 2d) * (i + 1)), sessionSchema);
 
             long timeStart = Instant.now().toEpochMilli();
             while (noaaIngester.hasNext()) {

--- a/samples/src/main/java/sustain/synopsis/samples/client/noaa/NoaaIngester.java
+++ b/samples/src/main/java/sustain/synopsis/samples/client/noaa/NoaaIngester.java
@@ -19,7 +19,6 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.List;
 import java.util.Set;
 
 public class NoaaIngester {
@@ -108,7 +107,7 @@ public class NoaaIngester {
             return;
         }
         try {
-            logger.info("Completed " + index + "/" + inputFiles.length);
+            logger.info("Starting " + (index + 1) + "/" + inputFiles.length);
             File currentFile = inputFiles[index++];
             FileInputStream fIn = new FileInputStream(currentFile);
             BufferedInputStream bIn = new BufferedInputStream(fIn);

--- a/storage/src/main/java/sustain/synopsis/storage/lsmtree/MemTable.java
+++ b/storage/src/main/java/sustain/synopsis/storage/lsmtree/MemTable.java
@@ -35,7 +35,7 @@ public class MemTable<K extends Comparable<K> & StreamSerializable, V extends St
         this.maxEntryCount = maxEntryCount;
     }
 
-    public boolean add(K key, V value) {
+    public boolean add(K key, V value) throws MergeError {
         try {
             lock.writeLock().lock();
             if (elements.containsKey(key)) {

--- a/storage/src/main/java/sustain/synopsis/storage/lsmtree/MergeError.java
+++ b/storage/src/main/java/sustain/synopsis/storage/lsmtree/MergeError.java
@@ -1,0 +1,7 @@
+package sustain.synopsis.storage.lsmtree;
+
+public class MergeError extends Throwable {
+    public MergeError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/storage/src/main/java/sustain/synopsis/storage/lsmtree/Mergeable.java
+++ b/storage/src/main/java/sustain/synopsis/storage/lsmtree/Mergeable.java
@@ -1,5 +1,5 @@
 package sustain.synopsis.storage.lsmtree;
 
 public interface Mergeable<T> {
-    void merge(T t);
+    void merge(T t) throws MergeError;
 }

--- a/storage/src/main/java/sustain/synopsis/storage/lsmtree/SSTableReader.java
+++ b/storage/src/main/java/sustain/synopsis/storage/lsmtree/SSTableReader.java
@@ -108,4 +108,8 @@ public class SSTableReader<K extends Comparable<K> & StreamSerializable> {
         readFully(channel, buffer);
         return isCompressed ? compressor.decompress(uncompressedLength, buffer.array()) : buffer.array();
     }
+
+    public void close() throws IOException {
+        channel.close();
+    }
 }

--- a/storage/src/test/java/sustain/synopsis/storage/lsmtree/MemTableTest.java
+++ b/storage/src/test/java/sustain/synopsis/storage/lsmtree/MemTableTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.*;
 class MemTableTest {
 
     @Test
-    void testAdd() {
+    void testAdd() throws MergeError {
         MemTable<LSMTestKey, LSMTestValue> memTable = new MemTable<>(1024); // 1 KB
         Assertions.assertFalse(memTable.add(new LSMTestKey(1), new LSMTestValue(256)));
 
@@ -27,7 +27,7 @@ class MemTableTest {
     }
 
     @Test
-    void testIsFullIfEntrySizeIsNotAvailable() {
+    void testIsFullIfEntrySizeIsNotAvailable() throws MergeError {
         // check if the size of the memTable is bound by the number of entries if the serialized size of an entry
         // cannot be derived.
         LSMTestValue mockedValue = mock(LSMTestValue.class);
@@ -44,7 +44,7 @@ class MemTableTest {
     }
 
     @Test
-    void testIterator() {
+    void testIterator() throws MergeError {
         MemTable<LSMTestKey, LSMTestValue> memTable = new MemTable<>(1024, 200);
         LSMTestValue[] values = new LSMTestValue[5];
         for (int i = 5; i > 0; i--) {
@@ -65,7 +65,7 @@ class MemTableTest {
     }
 
     @Test
-    void testGetEstimatedSize(){
+    void testGetEstimatedSize() throws MergeError {
         MemTable<LSMTestKey, LSMTestValue> memTable = new MemTable<>(1024); // 1 KB
         Assertions.assertEquals(0L, memTable.getEstimatedSize());
         memTable.add(new LSMTestKey(1), new LSMTestValue(32));
@@ -73,7 +73,7 @@ class MemTableTest {
     }
 
     @Test
-    void testFirstAndLastKeys(){
+    void testFirstAndLastKeys() throws MergeError {
         MemTable<LSMTestKey, LSMTestValue> memTable = new MemTable<>(1024);
         Assertions.assertNull(memTable.getFirstKey());
         Assertions.assertNull(memTable.getLastKey());
@@ -85,7 +85,7 @@ class MemTableTest {
     }
 
     @Test
-    void testEntryCount(){
+    void testEntryCount() throws MergeError {
         MemTable<LSMTestKey, LSMTestValue> memTable = new MemTable<>(1024);
         Assertions.assertEquals(0, memTable.getEntryCount());
         for(int i = 0; i < 5; i++){
@@ -95,7 +95,7 @@ class MemTableTest {
     }
 
     @Test
-    void testClear(){
+    void testClear() throws MergeError {
         MemTable<LSMTestKey, LSMTestValue> memTable = new MemTable<>(1024);
         for(int i = 0; i < 5; i++){
             memTable.add(new LSMTestKey(i), new LSMTestValue(32));


### PR DESCRIPTION
The objective of this change is to natively serialize a [Strand](https://github.com/Project-Sustain/synopsis-dht/blob/master/common/src/main/java/sustain/synopsis/common/Strand.java) as a Protocol Buffer message. The advantages are:

- Smaller network/storage footprint
- Easy to parse (for the clients)
- Faster serialization/deserialization

I've tried to handle the case for sparse data (only 1 observation per Strand) in this protobuff definition as documented in the file itself. The clients will have to do a simple check to see if the Strand represents multiple observations before accessing the data container related fields. @kevin-bruhwiler  is this doable at the visualization client?

Also clients are expected to know the order of the features. This is already stored in the metadata server. Clients can fetch this information at the beginning. [TargetedResponseMessage](https://github.com/Project-Sustain/synopsis-dht/blob/master/common/src/main/proto/targeted_query_service.proto) will be updated to include the session id that will be helpful for this lookup. @kevin-bruhwiler for the moment, we can hard code at the client side the order in which the features appear.

 [TargetedResponseMessage](https://github.com/Project-Sustain/synopsis-dht/blob/master/common/src/main/proto/targeted_query_service.proto) will contain a list of ProtoBuffSerializedStrand objects.